### PR TITLE
feat: Improve Error Handling and UI Feedback

### DIFF
--- a/.idea/deploymentTargetSelector.xml
+++ b/.idea/deploymentTargetSelector.xml
@@ -4,7 +4,7 @@
     <selectionStates>
       <SelectionState runConfigName="app">
         <option name="selectionMode" value="DROPDOWN" />
-        <DropdownSelection timestamp="2025-03-05T10:08:54.323651Z">
+        <DropdownSelection timestamp="2025-03-07T23:41:39.828601Z">
           <Target type="DEFAULT_BOOT">
             <handle>
               <DeviceId pluginId="LocalEmulator" identifier="path=/Users/amrahmed/.android/avd/Pixel_2_API_30.avd" />

--- a/app/src/main/java/com/example/thmanyah/core/extensions/ThrowableExtensions.kt
+++ b/app/src/main/java/com/example/thmanyah/core/extensions/ThrowableExtensions.kt
@@ -1,0 +1,9 @@
+package com.example.thmanyah.core.extensions
+
+import java.io.IOException
+
+fun Throwable.getMappedMessage():String{
+    return if (this is IOException)
+        "No internet connection"
+    else "Something went wrong"
+}

--- a/app/src/main/java/com/example/thmanyah/core/presentation/ui/PullToRefreshBox.kt
+++ b/app/src/main/java/com/example/thmanyah/core/presentation/ui/PullToRefreshBox.kt
@@ -1,0 +1,43 @@
+@file:OptIn(ExperimentalMaterial3Api::class)
+
+package com.example.thmanyah.core.presentation.ui
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxScope
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.pulltorefresh.PullToRefreshDefaults.Indicator
+import androidx.compose.material3.pulltorefresh.PullToRefreshState
+import androidx.compose.material3.pulltorefresh.pullToRefresh
+import androidx.compose.material3.pulltorefresh.rememberPullToRefreshState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+
+@Composable
+@ExperimentalMaterial3Api
+fun DefaultPullToRefreshBox(
+    isRefreshing: Boolean,
+    onRefresh: () -> Unit,
+    modifier: Modifier = Modifier,
+    isEnabled: Boolean = true,
+    state: PullToRefreshState = rememberPullToRefreshState(),
+    contentAlignment: Alignment = Alignment.TopStart,
+    indicator: @Composable BoxScope.() -> Unit = {
+            Indicator(
+                modifier = Modifier.align(Alignment.TopCenter),
+                isRefreshing = isRefreshing,
+                state = state
+            )
+    },
+    content: @Composable BoxScope.() -> Unit
+) {
+    Box(
+        modifier.pullToRefresh(state = state, isRefreshing = isRefreshing, onRefresh = onRefresh,
+            enabled = isEnabled),
+        contentAlignment = contentAlignment
+    ) {
+        content()
+        indicator()
+    }
+}

--- a/app/src/main/java/com/example/thmanyah/core/presentation/ui/SnackBar.kt
+++ b/app/src/main/java/com/example/thmanyah/core/presentation/ui/SnackBar.kt
@@ -19,8 +19,8 @@ import kotlinx.coroutines.launch
 fun DefaultSnackBar(
     modifier: Modifier,
     msg: String,
-    background: Color = SnackbarDefaults.color,
-    textColor: Color = MaterialTheme.colorScheme.surface
+    background: Color = Color.Red,
+    textColor: Color = Color.White
 ) {
     val snackState = remember { SnackbarHostState() }
     val snackScope = rememberCoroutineScope()

--- a/app/src/main/java/com/example/thmanyah/core/presentation/ui/StateView.kt
+++ b/app/src/main/java/com/example/thmanyah/core/presentation/ui/StateView.kt
@@ -11,7 +11,9 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import com.example.thmanyah.R
 
@@ -36,8 +38,9 @@ fun StateView(
             )
         }
         error?.let {
-            Column(Modifier.align(Alignment.Center)) {
-                Text(it)
+            Column(Modifier.align(Alignment.Center),
+                horizontalAlignment = Alignment.CenterHorizontally) {
+                Text(text = it, color = Color.White, textAlign = TextAlign.Center)
                 Spacer(modifier = Modifier.height(10.dp))
                 Button(onClick = onAction) {
                     Text(stringResource(R.string.label_retry))

--- a/app/src/main/java/com/example/thmanyah/features/sections/presentation/ui/SectionsScreen.kt
+++ b/app/src/main/java/com/example/thmanyah/features/sections/presentation/ui/SectionsScreen.kt
@@ -1,3 +1,5 @@
+@file:OptIn(ExperimentalMaterial3Api::class)
+
 package com.example.thmanyah.features.sections.presentation.ui
 
 import androidx.compose.foundation.background
@@ -12,6 +14,7 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -22,6 +25,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import com.example.thmanyah.core.extensions.OnBottomReached
+import com.example.thmanyah.core.presentation.ui.DefaultPullToRefreshBox
 import com.example.thmanyah.core.presentation.ui.StateView
 import com.example.thmanyah.core.presentation.ui.TabsView
 import com.example.thmanyah.features.sections.domain.entity.ContentType
@@ -55,10 +59,14 @@ fun SectionsScreen(
         }
     }
 
-    Box(
+    DefaultPullToRefreshBox(
         modifier = Modifier
             .fillMaxSize()
-            .background(MaterialTheme.colorScheme.background)
+            .background(MaterialTheme.colorScheme.background),
+        isRefreshing = homeUiModel?.showPullToRefresh == true,
+        onRefresh = {
+            viewModel.processIntent(SectionsIntent.RefreshHomeSections)
+        }
     ) {
         Column(
             modifier = Modifier
@@ -114,6 +122,7 @@ fun SectionsScreen(
         StateView(Modifier.fillMaxSize(),
             isLoading = homeUiModel?.showFullLoading,
             error = homeUiModel?.error,
+            snackError = homeUiModel?.snackError,
             onAction = {
                 viewModel.processIntent(SectionsIntent.LoadHomeSections)
             })

--- a/app/src/main/java/com/example/thmanyah/features/sections/presentation/uimodel/SectionUIModel.kt
+++ b/app/src/main/java/com/example/thmanyah/features/sections/presentation/uimodel/SectionUIModel.kt
@@ -12,7 +12,6 @@ data class SectionsListUiModel(
     val selectedCategoryIndex: Int? = null,
     val error: String? = null,
     val snackError: String? = null,
-    val isRefreshing: Boolean = false,
     val showFullLoading: Boolean = false,
     val showFooterLoading: Boolean = false,
     val showPullToRefresh: Boolean = false,

--- a/app/src/main/java/com/example/thmanyah/features/sections/presentation/uimodel/SectionsState.kt
+++ b/app/src/main/java/com/example/thmanyah/features/sections/presentation/uimodel/SectionsState.kt
@@ -10,7 +10,6 @@ data class SectionsListUiState(
     val headersCategories :List<String> = listOf("الكتب", "المقالات الصوتية", "البودكاست"), // todo  get from Api if possible
     val sections: List<SectionUiState> = emptyList(),
     val error: String? = null,
-    val snackError: String? = null,
     val selectedCategory:String? = headersCategories.first(), // todo should be assigned after fetching from api
     val hasNextPage: Boolean = false,
     val isRefreshing: Boolean = false,

--- a/app/src/main/java/com/example/thmanyah/features/sections/presentation/viewmodel/SectionsViewModel.kt
+++ b/app/src/main/java/com/example/thmanyah/features/sections/presentation/viewmodel/SectionsViewModel.kt
@@ -3,6 +3,7 @@ package com.example.thmanyah.features.sections.presentation.viewmodel
 import android.content.Context
 import androidx.lifecycle.viewModelScope
 import com.example.thmanyah.base.presentation.viewmodel.BaseViewModel
+import com.example.thmanyah.core.extensions.getMappedMessage
 import com.example.thmanyah.features.sections.domain.interactors.GetHomeSectionsUseCase
 import com.example.thmanyah.features.sections.domain.interactors.HasSectionsNextPageUseCase
 import com.example.thmanyah.features.sections.domain.interactors.SearchForSectionsUseCase
@@ -83,15 +84,14 @@ class SectionsViewModel @Inject constructor(
         ) {
             getHomeSectionsUseCase.invoke(isFirstPage)
                 .onStart {
-                    updateState { it.copy(isLoading = true, error = null, snackError = null) }
+                    updateState { it.copy(isLoading = true, error = null) }
                 }
                 .catch { exception ->
                     updateState {
                         it.copy(
                             isLoading = false,
                             isRefreshing = false,
-                            error = if (isFirstPage) exception.message else null,
-                            snackError = if (!isFirstPage) exception.message else null
+                            error =  exception.getMappedMessage(),
                         )
                     }
                 }
@@ -113,10 +113,10 @@ class SectionsViewModel @Inject constructor(
     private fun refreshHomeSections() {
         getHomeSectionsUseCase.invoke(true)
             .onStart {
-                updateState { it.copy(isRefreshing = true, snackError = null) }
+                updateState { it.copy(isRefreshing = true, error = null) }
             }
             .catch { exception ->
-                updateState { it.copy(isRefreshing = false, snackError = exception.message) }
+                updateState { it.copy(isRefreshing = false, error = exception.getMappedMessage()) }
             }
             .onEach { list ->
                 updateState { state ->
@@ -139,7 +139,8 @@ class SectionsViewModel @Inject constructor(
             showEmptyView = state.sections.isEmpty() && !state.isLoading,
             selectedCategoryIndex = state.headersCategories.indexOf(state.selectedCategory),
             sections = uiSections,
-            error = state.error,
+            error = if (state.sections.isEmpty()) state.error else null,
+            snackError = if (state.sections.isNotEmpty())state.error else null,
             headersCategories = state.headersCategories
         )
     }
@@ -155,14 +156,14 @@ class SectionsViewModel @Inject constructor(
         currentSearchJob?.cancel()
         currentSearchJob = searchForSectionsUseCase.invoke(query)
                 .onStart {
-                    updateState { it.copy(isLoading = true, error = null, snackError = null) }
+                    updateState { it.copy(isLoading = true, error = null) }
                 }
                 .catch { exception ->
                     updateState {
                         it.copy(
                             isLoading = false,
                             isRefreshing = false,
-                            error= exception.message,
+                            error= exception.getMappedMessage(),
                         )
                     }
                 }


### PR DESCRIPTION
This commit enhances the application's error handling and UI feedback mechanisms. Key changes include:

- **Error Handling**:
    - Implemented `Throwable.getMappedMessage()` extension to provide user-friendly error messages, such as "No internet connection" for `IOException`.
    - Refactored `SectionsViewModel` to use `getMappedMessage()` to handle exceptions in `getHomeSectionsUseCase` and `searchForSectionsUseCase`, providing more informative error messages.
    - Removed `snackError` from `SectionsState` and moved the check to `SectionUIModel` to show the snackbar only when there is data in the screen.
- **UI/UX Enhancements**:
    - Modified `DefaultSnackBar` to use a red background with white text.
    - Updated `StateView` to center-align the error text and make it white.
    - Introduced `DefaultPullToRefreshBox` to implement pull-to-refresh functionality with Material 3.
    - Used `DefaultPullToRefreshBox` in `SectionsScreen` for refreshing home sections.
- **Code Refactoring**:
    - `SectionsScreen` now uses a `DefaultPullToRefreshBox`.
    - Correctly handle errors in `refreshHomeSections` within `SectionsViewModel`.
    - `SectionsScreen` now has the ability to refresh sections by pull to refresh action.
    - The error message will be visible only if the screen is empty.